### PR TITLE
chore: add v5 manifest schema for bioc

### DIFF
--- a/pkg/metadata/schemas.go
+++ b/pkg/metadata/schemas.go
@@ -13,6 +13,7 @@ var validSchemas = []int{
 var validBiocSchemas = []int{
 	3,
 	4,
+	5,
 }
 
 func IsValidSchema(v version.ManifestVersion) bool {

--- a/pkg/metadata/schemas_test.go
+++ b/pkg/metadata/schemas_test.go
@@ -58,11 +58,13 @@ func (s *SchemaSuite) TestIsValidBiocSchema() {
 		{"v2", false},
 		{"v3", true},
 		{"v4", true},
+		{"v5", true},
 		{"v13", false},
 		{"1", false},
 		{"2", false},
 		{"3", true},
 		{"4", true},
+		{"5", true},
 		{"13", false},
 		{"v1/2", false},
 		{"v2/2", false},
@@ -73,6 +75,7 @@ func (s *SchemaSuite) TestIsValidBiocSchema() {
 		{"v2/2/4", false},
 		{"v3/2/4", true},
 		{"v4/2/4", true},
+		{"v5/2/4", true},
 		{"v13/2/4", false},
 	} {
 		v, err := version.ParseNewManifestVersion(test.version)

--- a/pkg/utils/filepath_getter.go
+++ b/pkg/utils/filepath_getter.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/rstudio/package-manager-rpackagerewriter/pkg/archive"
-	"github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v1"
-	"github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v2"
+	v1 "github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v1"
+	v2 "github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v2"
 )
 
 type FilePathGetter interface {
@@ -42,7 +42,7 @@ func (f *defaultFilePathGetterFactory) GetFilePathGetter(schemaVersion int) (Fil
 
 func (f *biocFilePathGetterFactory) GetFilePathGetter(schemaVersion int) (FilePathGetter, error) {
 	switch schemaVersion {
-	case 3, 4:
+	case 3, 4, 5:
 		// Bioc was originally created at parity with CRAN at version 3. Version 4 of bioc was a simple copy
 		//    of version 3 that was used to force a fresh sync so that a fix in the sync code would be picked
 		//    up. For both of these reasons, the Bioc transformer here is the same as the CRAN V2V3FilePathGetter.

--- a/pkg/utils/filepath_getter_test.go
+++ b/pkg/utils/filepath_getter_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/rstudio/package-manager-rpackagerewriter/pkg/archive"
-	"github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v1"
-	"github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v2"
+	v1 "github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v1"
+	v2 "github.com/rstudio/package-manager-rpackagerewriter/pkg/utils/v2"
 )
 
 func TestFilePathGetterSuite(t *testing.T) {
@@ -62,6 +62,10 @@ func (s *FilePathGetterSuite) TestGetBioc() {
 	s.Require().IsType(&v2.V2V3FilePathGetter{}, fpg)
 
 	fpg, err = fpf.GetFilePathGetter(4)
+	s.Require().Nil(err)
+	s.Require().IsType(&v2.V2V3FilePathGetter{}, fpg)
+
+	fpg, err = fpf.GetFilePathGetter(5)
 	s.Require().Nil(err)
 	s.Require().IsType(&v2.V2V3FilePathGetter{}, fpg)
 


### PR DESCRIPTION
I need to update this repo with v5 and I will consume it in the `rspm-manifest-tools` work I'm doing.